### PR TITLE
Black update 22.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "black" %}
-{% set version = "19.10b0" %}
-{% set sha256 = "c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539" %}
+{% set version = "0.22.6" %}
+{% set sha256 = "6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,6 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   entry_points:
@@ -19,14 +18,17 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
   run:
-    - python >=3.6
-    - click >=6.5
-    - attrs >=18.1.0
-    - appdirs
-    - toml >=0.9.4
+    - python
+    - click >=8.0.0
+    - platformdirs >=2
+    - tomli >=1.1.0 #[<py311]
+    - typed-ast >=1.4.2 #[<py38]              #No support for 37?k
+    - pathspec >=0.9.0                        #LAST VERSION is 0.7.0
+    - typing_extensions >=3.10.0.0 #[<py310]
+    - mypy_extensions >=0.4.3                 #NON EXISTENT in main
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ about:
     to cease control over minutiae of hand-formatting. In return, Black gives
     you speed, determinism, and freedom from pycodestyle nagging about
     formatting. You will save time and mental energy for more important matters.
-  doc_url: https://github.com/psf/black
+  doc_url: https://black.readthedocs.io/
   dev_url: https://github.com/psf/black
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ outputs:
   - name: {{ name }}
     build:
       skip: True # [py<36]
-      script: python -m pip install --ignore-installed --no-deps -vv .
+      script: "{{ PYTHON }} -m pip install --ignore-installed --no-deps -vv ."
       entry_points:
         - black = black:patched_main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name|lower }}-recipe
   version: {{ version }}
 
 source:
@@ -15,9 +15,9 @@ build:
 
 outputs:
   - name: {{ name }}
-    script: "{{ PYTHON }} -m pip install . --no-deps -vv"
     build:
       skip: True # [py<36]
+      script: python -m pip install --ignore-installed --no-deps -vv .
       entry_points:
         - black = black:patched_main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
     - black --help
 
 about:
-  home: https://github.com/python/black
+  home: https://github.com/psf/black
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -46,8 +46,8 @@ about:
     to cease control over minutiae of hand-formatting. In return, Black gives
     you speed, determinism, and freedom from pycodestyle nagging about
     formatting. You will save time and mental energy for more important matters.
-  doc_url: https://github.com/python/black
-  dev_url: https://github.com/python/black
+  doc_url: https://github.com/psf/black
+  dev_url: https://github.com/psf/black
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   skip: True # [py<36]
-  script: "{{ PYTHON }} -m pip install --ignore-installed --no-deps -vv ."
+  script: "{{ PYTHON }} -m pip install --no-deps -vv ."
   entry_points:
     - black = black:patched_main
     - blackd = blackd:patched_main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,9 @@ requirements:
   host:
     - python
     - pip
+    - setuptools >=45.0
+    - setuptools_scm[toml] >=6.3.1
+    - wheel
   run:
     - python
     - click >=8.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,54 +12,37 @@ source:
 
 build:
   number: 0
+  skip: True # [py<36]
+  script: "{{ PYTHON }} -m pip install --ignore-installed --no-deps -vv ."
+  entry_points:
+    - black = black:patched_main
+    - blackd = blackd:patched_main
 
-outputs:
-  - name: {{ name }}
-    build:
-      skip: True # [py<36]
-      script: "{{ PYTHON }} -m pip install --ignore-installed --no-deps -vv ."
-      entry_points:
-        - black = black:patched_main
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools >=45.0
+    - setuptools_scm[toml] >=6.3.1
+    - wheel
+  run:
+    - python
+    - click >=8.0.0
+    - platformdirs >=2
+    - tomli >=1.1.0 # [py<311]
+    - typed-ast >=1.4.2 # [py<38]
+    - pathspec >=0.9.0
+    - typing_extensions >=3.10.0.0 # [py<310]
+    - mypy_extensions >=0.4.3
+  run_constrained:
+    - colorama >=0.4.3
+    - uvloop >=0.15.2
+    - aiohttp >=3.7.4
 
-    requirements:
-      host:
-        - python
-        - pip
-        - setuptools >=45.0
-        - setuptools_scm[toml] >=6.3.1
-        - wheel
-      run:
-        - python
-        - click >=8.0.0
-        - platformdirs >=2
-        - tomli >=1.1.0 # [py<311]
-        - typed-ast >=1.4.2 # [py<38]
-        - pathspec >=0.9.0
-        - typing_extensions >=3.10.0.0 # [py<310]
-        - mypy_extensions >=0.4.3
-      run_constrained:
-        - colorama >=0.4.3
-        - uvloop >=0.15.2
-
-    test:
-      commands:
-        - pip check
-        - black --help
-
-  - name: {{ name }}d
-    build:
-      entry_points:
-        - blackd = blackd:patched_main
-
-    requirements:
-      run:
-        - {{ pin_subpackage('black', max_pin='x.x.x') }}
-        - aiohttp >=3.7.4
-
-    test:
-      commands:
-        - black --help
-        - blackd --help
+test:
+  commands:
+    - pip check
+    - black --help
 
 about:
   home: https://github.com/psf/black

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,9 @@ requirements:
     - aiohttp >=3.7.4
 
 test:
+  requires:
+    - python
+    - pip
   commands:
     - black --help
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,8 +41,8 @@ requirements:
 
 test:
   commands:
-    - pip check
     - black --help
+    - pip check
 
 about:
   home: https://github.com/psf/black

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9" %}
 
 package:
-  name: {{ name|lower }}-recipe
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,30 +12,55 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  entry_points:
-    - black = black:main
 
-requirements:
-  host:
-    - python
-    - pip
-    - setuptools >=45.0
-    - setuptools_scm[toml] >=6.3.1
-    - wheel
-  run:
-    - python
-    - click >=8.0.0
-    - platformdirs >=2
-    - tomli >=1.1.0 # [py<311]
-    - typed-ast >=1.4.2 # [py<38]
-    - pathspec >=0.9.0
-    - typing_extensions >=3.10.0.0 # [py<310]
-    - mypy_extensions >=0.4.3
+outputs:
+  - name: {{ name }}
+    script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+    build:
+      skip: True # [py<36]
+      entry_points:
+        - black = black:patched_main
 
-test:
-  commands:
-    - black --help
+    requirements:
+      host:
+        - python
+        - pip
+        - setuptools >=45.0
+        - setuptools_scm[toml] >=6.3.1
+        - wheel
+      run:
+        - python
+        - click >=8.0.0
+        - platformdirs >=2
+        - tomli >=1.1.0 # [py<311]
+        - typed-ast >=1.4.2 # [py<38]
+        - pathspec >=0.9.0
+        - typing_extensions >=3.10.0.0 # [py<310]
+        - mypy_extensions >=0.4.3
+      run_constrained:
+        - colorama >=0.4.3
+        - uvloop >=0.15.2
+
+    test:
+      commands:
+        - pip check
+        - black --help
+
+  - name: {{ name }}d
+    script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+    build:
+      entry_points:
+        - blackd = blackd:patched_main
+
+    requirements:
+      run:
+        - {{ pin_subpackage('black', max_pin='x.x.x') }}
+        - aiohttp >=3.7.4
+
+    test:
+      commands:
+        - black --help
+        - blackd --help
 
 about:
   home: https://github.com/psf/black

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,11 +24,11 @@ requirements:
     - python
     - click >=8.0.0
     - platformdirs >=2
-    - tomli >=1.1.0 #[<py311]
-    - typed-ast >=1.4.2 #[<py38]              #No support for 37?k
-    - pathspec >=0.9.0                        #LAST VERSION is 0.7.0
+    - tomli >=1.1.0     #[<=py310]
+    - typed-ast >=1.4.2 #[<py38]
+    - pathspec >=0.9.0
     - typing_extensions >=3.10.0.0 #[<py310]
-    - mypy_extensions >=0.4.3                 #NON EXISTENT in main
+    - mypy_extensions >=0.4.3
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,6 @@ outputs:
         - black --help
 
   - name: {{ name }}d
-    script: "{{ PYTHON }} -m pip install . --no-deps -vv"
     build:
       entry_points:
         - blackd = blackd:patched_main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,7 @@ about:
     to cease control over minutiae of hand-formatting. In return, Black gives
     you speed, determinism, and freedom from pycodestyle nagging about
     formatting. You will save time and mental energy for more important matters.
-  doc_url: https://black.readthedocs.io/
+  doc_url: https://black.readthedocs.io/en/stable/
   dev_url: https://github.com/psf/black
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "black" %}
-{% set version = "0.22.6" %}
+{% set version = "22.6.0" %}
 {% set sha256 = "6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9" %}
 
 package:
@@ -24,10 +24,10 @@ requirements:
     - python
     - click >=8.0.0
     - platformdirs >=2
-    - tomli >=1.1.0     #[<=py310]
-    - typed-ast >=1.4.2 #[<py38]
+    - tomli >=1.1.0 # [py<311]
+    - typed-ast >=1.4.2 # [py<38]
     - pathspec >=0.9.0
-    - typing_extensions >=3.10.0.0 #[<py310]
+    - typing_extensions >=3.10.0.0 # [py<310]
     - mypy_extensions >=0.4.3
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
   run:
     - python
     - click >=8.0.0
+    - dataclasses >=0.6  # [py<37]
     - platformdirs >=2
     - tomli >=1.1.0 # [py<311]
     - typed-ast >=1.4.2 # [py<38]
@@ -35,10 +36,11 @@ requirements:
     - typing_extensions >=3.10.0.0 # [py<310]
     - mypy_extensions >=0.4.3
   run_constrained:
-    - colorama >=0.4.3
-    - uvloop >=0.15.2
-    - aiohttp >=3.7.4
-
+    - aiohttp >=3.7.4 # for blackd
+    - colorama >=0.4.3 # for colorama extra
+    - uvloop >=0.15.2 # for uvloop extra
+    # - ipython >=7.8.0 # for jupyter extra
+    # - tokenize-rt >=3.2.0 for jupyter extra (not in conda defaults currently)
 test:
   requires:
     - python


### PR DESCRIPTION
Black from 19.3 to 22.6

License: https://github.com/psf/black/blob/22.6.0/LICENSE
Changelog: https://github.com/psf/black/blob/22.6.0/CHANGES.md
Requirements:

https://github.com/psf/black/blob/22.6.0/pyproject.toml
https://github.com/psf/black/blob/22.6.0/setup.py

Update Notes:
- updated version and hash
- dependencies
- urls 
