### PR TITLE
Update black to 23.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,8 @@ requirements:
     # - ipython >=7.8.0 # for jupyter extra
     # - tokenize-rt >=3.2.0 for jupyter extra (not in conda defaults currently)
 test:
+  imports:
+    - black
   requires:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "black" %}
-{% set version = "22.6.0" %}
-{% set sha256 = "6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9" %}
+{% set version = "23.3.0" %}
+{% set sha256 = "1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940" %}
 
 package:
   name: {{ name|lower }}
@@ -9,6 +9,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - patches/001-remove-fancy-pypi-readme.patch
 
 build:
   number: 0
@@ -19,22 +21,26 @@ build:
     - blackd = blackd:patched_main
 
 requirements:
+  build:
+    - patch                # [unix]
+    - m2-patch             # [win]
+
   host:
     - python
     - pip
-    - setuptools >=45.0
-    - setuptools_scm[toml] >=6.3.1
+    - hatchling
+    - hatch-vcs
     - wheel
   run:
     - python
     - click >=8.0.0
-    - dataclasses >=0.6  # [py<37]
+    - mypy_extensions >=0.4.3
+    - packaging >=22.0
+    - pathspec >=0.9.0
     - platformdirs >=2
     - tomli >=1.1.0 # [py<311]
     - typed-ast >=1.4.2 # [py<38]
-    - pathspec >=0.9.0
     - typing_extensions >=3.10.0.0 # [py<310]
-    - mypy_extensions >=0.4.3
   run_constrained:
     - aiohttp >=3.7.4 # for blackd
     - colorama >=0.4.3 # for colorama extra

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   host:
     - python
     - pip
-    - hatchling
+    - hatchling >=1.8.0
     - hatch-vcs
     - wheel
   run:

--- a/recipe/patches/001-remove-fancy-pypi-readme.patch
+++ b/recipe/patches/001-remove-fancy-pypi-readme.patch
@@ -1,0 +1,26 @@
+diff --git a/black-23.3.0/pyproject.toml b/black-23.3.0-hack/pyproject.toml
+index 435626a..c785aa3 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -26,7 +26,7 @@ preview = true
+ # NOTE: You don't need this in your own Black configuration.
+ 
+ [build-system]
+-requires = ["hatchling>=1.8.0", "hatch-vcs", "hatch-fancy-pypi-readme"]
++requires = ["hatchling>=1.8.0", "hatch-vcs"]
+ build-backend = "hatchling.build"
+ 
+ [project]
+@@ -93,13 +93,6 @@ blackd = "blackd:patched_main [d]"
+ Changelog = "https://github.com/psf/black/blob/main/CHANGES.md"
+ Homepage = "https://github.com/psf/black"
+ 
+-[tool.hatch.metadata.hooks.fancy-pypi-readme]
+-content-type = "text/markdown"
+-fragments = [
+-  { path = "README.md" },
+-  { path = "CHANGES.md" },
+-]
+-
+ [tool.hatch.version]
+ source = "vcs"


### PR DESCRIPTION
Update black to newest version. The main changes were:
* Using hatchling to build,
* Patching out the usage of fancy-pypi-readme. The patch was modeled after what was done in jsonschema-feedstock for the same issue (https://github.com/AnacondaRecipes/jsonschema-feedstock/commit/121b731c79609ceaa48d5d3786a52dd578db24c7)

