### PR TITLE
black 26.3.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
+channels:
+  - https://staging.continuum.io/pbp/fs/pytokens-feedstock/pr3/d18c605

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/pytokens-feedstock/pr3/d18c605

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - packaging >=22.0
     - pathspec >=1.0.0
     - platformdirs >=2
-    - pytokens >=0.3.0
+    - pytokens >=0.4.0,<0.5.0
     - tomli >=1.1.0  # [py<311]
     - typing_extensions >=4.0.1  # [py<311]
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "black" %}
-{% set version = "26.1.0" %}
+{% set version = "26.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d294ac3340eef9c9eb5d29288e96dc719ff269a88e27b396340459dd85da4c58
+  sha256: 2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-13303](https://anaconda.atlassian.net/browse/PKG-13303)
- [Upstream repository](https://github.com/psf/black/tree/26.3.1)
- [Upstream changelog/diff](https://github.com/psf/black/releases)

### Explanation of changes:

- Bump version number
- Update dependencies to match upstream
- fixes https://www.cve.org/CVERecord?id=CVE-2026-31900


[PKG-13303]: https://anaconda.atlassian.net/browse/PKG-13303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ