### PR TITLE
PKG-15086: Update black to 26.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "black" %}
-{% set version = "26.3.1" %}
+{% set version = "26.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07
+  sha256: dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,8 @@ requirements:
   run_constrained:
     - aiohttp >=3.10
     - colorama >=0.4.3
-    - uvloop >=0.15.2
+    - uvloop >=0.15.2 # [not win]
+    - winloop >=0.5.0 # [win]
     - ipython >=7.8.0
     - tokenize-rt >=3.2.0
 


### PR DESCRIPTION
## black 26.5.1

**Destination channel:** defaults

### Links
- [PKG-15086](https://anaconda.atlassian.net/browse/PKG-15086)
- [PyPI](https://pypi.org/project/black/26.5.1/)
- [GitHub](https://github.com/psf/black)

### Explanation of changes:
- Updated black from 26.3.1 to 26.5.1
- No dependency changes

[PKG-15086]: https://anaconda.atlassian.net/browse/PKG-15086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ